### PR TITLE
Remove 'fs' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "full-resolution"
   ],
   "dependencies": {
-    "fs": "*",
     "https": "*",
     "url": "*",
     "follow-redirects": "*",


### PR DESCRIPTION
Ref: http://npm.im/fs

Also not sure that you need `https` or `url`, since I think those are probably Node.js native so the npm modules wouldn't be used and just bring in dead code.
